### PR TITLE
Create Dockerfile to build wxPython

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.8.1-buster
+
+LABEL maintainer="FoxGuard Solutions"
+LABEL website="https://foxguardsolutions.com/"
+
+RUN apt-get update
+RUN apt-get install -y build-essential libgtk-3-dev
+RUN pip install -U -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/debian-9 wxPython

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# wxpython
-Docker image for wxpython builds
+# Docker Image for wxPython
+
+Building Linux based Docker images for wxPython can pose problems given all the flavors and customizations of Linux.  The [suggestion from wxPython was to build custom Docker images](https://wxpython.org/blog/2017-08-17-builds-for-linux-with-pip/index.html) if they don't provide a supported wheel.  The Dockerfile in this repo will build wxPython ontop of a `python:3.8.1-buster` image.  It's important to pre-build this image considering how long it takes to build wxPython.  This makes it quicker for other images to depend on this image.


### PR DESCRIPTION
This image is based on Debian Buster (which is Debian 10) but I'm pulling the Debian 9 source since that is the latest available.  Building this image is very time consuming (upwards of a hour) which is why I wanted to pull this out into its own repository and pre-build the image so that we can depend on it elsewhere.